### PR TITLE
Scroll to the top of pages when they render

### DIFF
--- a/src/.eslintrc.json
+++ b/src/.eslintrc.json
@@ -4,5 +4,8 @@
     "@mapbox/eslint-config-mapbox/import",
     "@mapbox/eslint-config-mapbox/react",
     "prettier"
-  ]
+  ],
+  "env": {
+    "browser": true
+  }
 }

--- a/src/component-page.js
+++ b/src/component-page.js
@@ -2,6 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "@reach/router";
 import ComponentCase from "./component-case";
+import ScrollToTop from "./scroll-to-top";
 
 class ComponentPage extends React.Component {
   render() {
@@ -18,6 +19,7 @@ class ComponentPage extends React.Component {
 
     return (
       <div>
+        <ScrollToTop />
         <div style={{ marginBottom: 12 }}>
           <Link to="/" style={{ color: "#4264fb", textDecoration: "none" }}>
             Back to component list

--- a/src/scroll-to-top.js
+++ b/src/scroll-to-top.js
@@ -1,0 +1,16 @@
+import React from "react";
+
+class ScrollToTop extends React.Component {
+  shouldComponentUpdate() {
+    return false;
+  }
+  componentDidMount() {
+    document.body.scrollTop = 0;
+    document.documentElement.scrollTop = 0;
+  }
+  render() {
+    return null;
+  }
+}
+
+export default ScrollToTop;

--- a/src/table-of-contents.js
+++ b/src/table-of-contents.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { Link } from "@reach/router";
+import ScrollToTop from "./scroll-to-top";
 
 class TableOfContents extends React.Component {
   render() {
@@ -18,6 +19,7 @@ class TableOfContents extends React.Component {
 
     return (
       <div>
+        <ScrollToTop />
         <h1
           style={{
             margin: "0 0 24px 0",


### PR DESCRIPTION
React Router won't automatically scroll to the to top when you change pages. This PR adds that functionality, because I think that's always what we want when switching pages in this app.